### PR TITLE
Fix .ipynb notebook loading logic

### DIFF
--- a/Github_repo_analyser_final.ipynb
+++ b/Github_repo_analyser_final.ipynb
@@ -697,7 +697,7 @@
         "        try:\n",
         "            loader = None\n",
         "            if ext == 'ipynb':\n",
-        "                loader = NotebookLoader(str(repo_path), include_outputs=True, max_output_length=20, remove_newline=True)\n",
+        "                loader = DirectoryLoader(repo_path, glob=glob_pattern, loader_cls=NotebookLoader, loader_kwargs={\"include_outputs\": True, \"max_output_length\": 20, \"remove_newline\": True})\n",
         "            else:\n",
         "                loader = DirectoryLoader(repo_path, glob=glob_pattern)\n",
         "\n",


### PR DESCRIPTION
## Summary
- fix notebook loader path handling in `Github_repo_analyser_final.ipynb`

## Testing
- `python -m json.tool Github_repo_analyser_final.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_687cd4d2d63c8330baef7e3032462a42